### PR TITLE
fix application status response length

### DIFF
--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -471,7 +471,7 @@ public class KeycardApplet extends Applet {
    */
   private short getApplicationStatus(byte[] apduBuffer, short off) {
     apduBuffer[off++] = TLV_APPLICATION_STATUS_TEMPLATE;
-    apduBuffer[off++] = 12;
+    apduBuffer[off++] = 9;
     apduBuffer[off++] = TLV_INT;
     apduBuffer[off++] = 1;
     apduBuffer[off++] = pin.getTriesRemaining();


### PR DESCRIPTION
In the past we removed the `hasECPointMultiplication` property from the application status response, but we forgot to update the response length