### PR TITLE
Add seed flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ javacard {
       className = 'NDEFApplet'
     }
     
-    version = '2.2'
+    version = '2.3'
   }
 }
 
@@ -54,7 +54,7 @@ dependencies {
   testCompile(files("../jcardsim/jcardsim-3.0.5-SNAPSHOT.jar"))
   testCompile('org.web3j:core:2.3.1')
   testCompile('org.bitcoinj:bitcoinj-core:0.14.5')
-  testCompile('com.github.status-im.status-keycard-java:desktop:2.2.1')
+  testCompile('com.github.status-im.status-keycard-java:desktop:5771994')
   testCompile('org.bouncycastle:bcprov-jdk15on:1.60')
   testCompile("org.junit.jupiter:junit-jupiter-api:5.1.1")
   testRuntime("org.junit.jupiter:junit-jupiter-engine:5.1.1")

--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -685,7 +685,9 @@ public class KeycardApplet extends Applet {
         loadKeyPair(apduBuffer);
         break;
       case LOAD_KEY_P1_SEED:
+        // If you load a seed this way, it will NOT be exportable
         loadSeed(apduBuffer);
+        masterSeedFlag = SFLAG_NONE;
         break;
       default:
         ISOException.throwIt(ISO7816.SW_INCORRECT_P1P2);

--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -8,7 +8,7 @@ import javacardx.crypto.Cipher;
  * The applet's main class. All incoming commands a processed by this class.
  */
 public class KeycardApplet extends Applet {
-  static final short APPLICATION_VERSION = (short) 0x0202;
+  static final short APPLICATION_VERSION = (short) 0x0203;
 
   static final byte INS_GET_STATUS = (byte) 0xF2;
   static final byte INS_SET_NDEF = (byte) 0xF3;
@@ -25,6 +25,8 @@ public class KeycardApplet extends Applet {
   static final byte INS_SIGN = (byte) 0xC0;
   static final byte INS_SET_PINLESS_PATH = (byte) 0xC1;
   static final byte INS_EXPORT_KEY = (byte) 0xC2;
+  static final byte INS_GET_DATA = (byte) 0xCA;
+  static final byte INS_STORE_DATA = (byte) 0xE2;
 
   static final short SW_REFERENCED_DATA_NOT_FOUND = (short) 0x6A88;
 
@@ -35,6 +37,7 @@ public class KeycardApplet extends Applet {
   static final byte KEY_PATH_MAX_DEPTH = 10;
   static final byte PAIRING_MAX_CLIENT_COUNT = 5;
   static final byte UID_LENGTH = 16;
+  static final byte MAX_DATA_LENGTH = 127;
 
   static final short CHAIN_CODE_SIZE = 32;
   static final short KEY_UID_LENGTH = 32;
@@ -141,6 +144,8 @@ public class KeycardApplet extends Applet {
 
   private byte[] derivationOutput;
 
+  private byte[] data;
+
   /**
    * Invoked during applet installation. Creates an instance of this class. The installation parameters are passed in
    * the given buffer.
@@ -200,6 +205,8 @@ public class KeycardApplet extends Applet {
     expectedEntropy = -1;
 
     derivationOutput = JCSystem.makeTransientByteArray((short) (Crypto.KEY_SECRET_SIZE + CHAIN_CODE_SIZE), JCSystem.CLEAR_ON_RESET);
+
+    data = new byte[MAX_DATA_LENGTH + 1];
 
     register(bArray, (short) (bOffset + 1), bArray[bOffset]);
   }
@@ -282,6 +289,12 @@ public class KeycardApplet extends Applet {
           break;
         case INS_EXPORT_KEY:
           exportKey(apdu);
+          break;
+        case INS_GET_DATA:
+          getData(apdu);
+          break;
+        case INS_STORE_DATA:
+          storeData(apdu);
           break;
         default:
           ISOException.throwIt(ISO7816.SW_INS_NOT_SUPPORTED);
@@ -1432,6 +1445,52 @@ public class KeycardApplet extends Applet {
     apduBuffer[(SecureChannel.SC_OUT_OFFSET + 1)] = (byte) (len - 2);
 
     secureChannel.respond(apdu, len, ISO7816.SW_NO_ERROR);
+  }
+
+  /**
+   * Processes the GET DATA command.
+   *
+   * @param apdu the JCRE-owned APDU object.
+   */
+  private void getData(APDU apdu) {
+    byte[] apduBuffer = apdu.getBuffer();
+
+    if (secureChannel.isOpen()) {
+      secureChannel.preprocessAPDU(apduBuffer);
+    }
+
+    short outLen = Util.makeShort((byte) 0x00, data[0]);
+    Util.arrayCopyNonAtomic(data, (short) 1, apduBuffer, SecureChannel.SC_OUT_OFFSET, outLen);
+
+    if (secureChannel.isOpen()) {
+      secureChannel.respond(apdu, outLen, ISO7816.SW_NO_ERROR);
+    } else {
+      apdu.setOutgoingAndSend(SecureChannel.SC_OUT_OFFSET, outLen);
+    }
+  }
+
+  /**
+   * Processes the STORE DATA command. Requires an open secure channel and the PIN to be verified.
+   *
+   * @param apdu the JCRE-owned APDU object.
+   */
+  private void storeData(APDU apdu) {
+    byte[] apduBuffer = apdu.getBuffer();
+    secureChannel.preprocessAPDU(apduBuffer);
+
+    if (!pin.isValidated()) {
+      ISOException.throwIt(ISO7816.SW_CONDITIONS_NOT_SATISFIED);
+    }
+
+    short dataLen = Util.makeShort((byte) 0x00, apduBuffer[ISO7816.OFFSET_LC]);
+
+    if (dataLen > MAX_DATA_LENGTH) {
+      ISOException.throwIt(ISO7816.SW_WRONG_DATA);
+    }
+
+    JCSystem.beginTransaction();
+    Util.arrayCopy(apduBuffer, ISO7816.OFFSET_LC, data, (short) 0, (short)(dataLen + 1));
+    JCSystem.commitTransaction();
   }
 
   /**


### PR DESCRIPTION
Adds a flag to the `masterSeed` when it is generated or imported.

- [ ] Add default non-exportable flag to `loadKey`

- [ ] Add `loadSeedWithFlag` APDU

- [ ] Add default non-exportable flag to `generateKey`

- [ ] Add `generateSeedWithFlag` APDU

- [ ] Test all pubkeys are correct and all flags