### PR TITLE
add chain code export and remove derivation caches

### DIFF
--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -1199,14 +1199,17 @@ public class KeycardApplet extends Applet {
       apduBuffer[off++] = TLV_PUB_KEY;
       off++;
       len = secp256k1.derivePublicKey(derivationOutput, (short) 0, apduBuffer, off);
-      
-      if (extendedPublic) {
-        Util.arrayCopyNonAtomic(derivationOutput, Crypto.KEY_SECRET_SIZE, apduBuffer, (short) (off + len), CHAIN_CODE_SIZE);
-        len += CHAIN_CODE_SIZE;
-      }
-
       apduBuffer[(short) (off - 1)] = (byte) len;
       off += len;
+
+      if (extendedPublic) {
+        apduBuffer[off++] = TLV_CHAIN_CODE;  
+        off++;      
+        Util.arrayCopyNonAtomic(derivationOutput, Crypto.KEY_SECRET_SIZE, apduBuffer, off, CHAIN_CODE_SIZE);
+        len = CHAIN_CODE_SIZE;
+        apduBuffer[(short) (off - 1)] = (byte) len;
+        off += len;        
+      }
     } else {
       apduBuffer[off++] = TLV_PRIV_KEY;
       off++;

--- a/src/test/java/im/status/keycard/KeycardTest.java
+++ b/src/test/java/im/status/keycard/KeycardTest.java
@@ -1281,19 +1281,19 @@ public class KeycardTest {
     response = cmdSet.exportCurrentKey(true);
     assertEquals(0x9000, response.getSw());
     byte[] keyTemplate = response.getData();
-    verifyExportedKey(keyTemplate, keyPair, chainCode, new int[] { 0x8000002b, 0x8000003c, 0x8000062d, 0x00000000 }, true, false);
+    verifyExportedKey(keyTemplate, keyPair, chainCode, new int[] { 0x8000002b, 0x8000003c, 0x8000062d, 0x00000000 }, true);
 
     // Derive & Make current
     response = cmdSet.exportKey(new byte[] {(byte) 0x80, 0x00, 0x00, 0x2B, (byte) 0x80, 0x00, 0x00, 0x3C, (byte) 0x80, 0x00, 0x06, 0x2D, (byte) 0x00, 0x00, 0x00, 0x00, (byte) 0x00, 0x00, 0x00, 0x00}, KeycardApplet.DERIVE_P1_SOURCE_MASTER,true,false);
     assertEquals(0x9000, response.getSw());
     keyTemplate = response.getData();
-    verifyExportedKey(keyTemplate, keyPair, chainCode, new int[] { 0x8000002b, 0x8000003c, 0x8000062d, 0x00000000, 0x00000000 }, false, false);
+    verifyExportedKey(keyTemplate, keyPair, chainCode, new int[] { 0x8000002b, 0x8000003c, 0x8000062d, 0x00000000, 0x00000000 }, false);
 
     // Derive without making current
     response = cmdSet.exportKey(new byte[] {(byte) 0x00, 0x00, 0x00, 0x01}, KeycardApplet.DERIVE_P1_SOURCE_PARENT, false,false);
     assertEquals(0x9000, response.getSw());
     keyTemplate = response.getData();
-    verifyExportedKey(keyTemplate, keyPair, chainCode, new int[] { 0x8000002b, 0x8000003c, 0x8000062d, 0x00000000, 0x00000001 }, false, true);
+    verifyExportedKey(keyTemplate, keyPair, chainCode, new int[] { 0x8000002b, 0x8000003c, 0x8000062d, 0x00000000, 0x00000001 }, false);
     response = cmdSet.getStatus(KeycardApplet.GET_STATUS_P1_KEY_PATH);
     assertEquals(0x9000, response.getSw());
     assertArrayEquals(new byte[] {(byte) 0x80, 0x00, 0x00, 0x2B, (byte) 0x80, 0x00, 0x00, 0x3C, (byte) 0x80, 0x00, 0x06, 0x2D, (byte) 0x00, 0x00, 0x00, 0x00, (byte) 0x00, 0x00, 0x00, 0x00}, response.getData());
@@ -1302,7 +1302,7 @@ public class KeycardTest {
     response = cmdSet.exportCurrentKey(false);
     assertEquals(0x9000, response.getSw());
     keyTemplate = response.getData();
-    verifyExportedKey(keyTemplate, keyPair, chainCode, new int[] { 0x8000002b, 0x8000003c, 0x8000062d, 0x00000000, 0x00000000 }, false, false);
+    verifyExportedKey(keyTemplate, keyPair, chainCode, new int[] { 0x8000002b, 0x8000003c, 0x8000062d, 0x00000000, 0x00000000 }, false);
 
     // Reset
     response = cmdSet.deriveKey(new byte[0], KeycardApplet.DERIVE_P1_SOURCE_MASTER);
@@ -1673,7 +1673,7 @@ public class KeycardTest {
     }
   }
 
-  private void verifyExportedKey(byte[] keyTemplate, KeyPair keyPair, byte[] chainCode, int[] path, boolean publicOnly, boolean noPubKey) {
+  private void verifyExportedKey(byte[] keyTemplate, KeyPair keyPair, byte[] chainCode, int[] path, boolean publicOnly) {
     if (!cmdSet.getApplicationInfo().hasKeyManagementCapability()) {
       return;
     }
@@ -1682,14 +1682,11 @@ public class KeycardTest {
     assertEquals(KeycardApplet.TLV_KEY_TEMPLATE, keyTemplate[0]);
     int pubKeyLen = 0;
 
-    if (!noPubKey) {
+    if (publicOnly) {
       assertEquals(KeycardApplet.TLV_PUB_KEY, keyTemplate[2]);
       byte[] pubKey = Arrays.copyOfRange(keyTemplate, 4, 4 + keyTemplate[3]);
       assertArrayEquals(key.getPubKey(), pubKey);
       pubKeyLen = 2 + pubKey.length;
-    }
-
-    if (publicOnly) {
       assertEquals(pubKeyLen, keyTemplate[1]);
       assertEquals(pubKeyLen + 2, keyTemplate.length);
     } else {

--- a/src/test/java/im/status/keycard/KeycardTest.java
+++ b/src/test/java/im/status/keycard/KeycardTest.java
@@ -1281,19 +1281,19 @@ public class KeycardTest {
     response = cmdSet.exportCurrentKey(true);
     assertEquals(0x9000, response.getSw());
     byte[] keyTemplate = response.getData();
-    verifyExportedKey(keyTemplate, keyPair, chainCode, new int[] { 0x8000002b, 0x8000003c, 0x8000062d, 0x00000000 }, true);
+    verifyExportedKey(keyTemplate, keyPair, chainCode, new int[] { 0x8000002b, 0x8000003c, 0x8000062d, 0x00000000 }, true, false);
 
     // Derive & Make current
-    response = cmdSet.exportKey(new byte[] {(byte) 0x80, 0x00, 0x00, 0x2B, (byte) 0x80, 0x00, 0x00, 0x3C, (byte) 0x80, 0x00, 0x06, 0x2D, (byte) 0x00, 0x00, 0x00, 0x00, (byte) 0x00, 0x00, 0x00, 0x00}, KeycardApplet.DERIVE_P1_SOURCE_MASTER,true,false);
+    response = cmdSet.exportKey(new byte[] {(byte) 0x80, 0x00, 0x00, 0x2B, (byte) 0x80, 0x00, 0x00, 0x3C, (byte) 0x80, 0x00, 0x06, 0x2D, (byte) 0x00, 0x00, 0x00, 0x00, (byte) 0x00, 0x00, 0x00, 0x00}, KeycardApplet.DERIVE_P1_SOURCE_MASTER, true, false);
     assertEquals(0x9000, response.getSw());
     keyTemplate = response.getData();
-    verifyExportedKey(keyTemplate, keyPair, chainCode, new int[] { 0x8000002b, 0x8000003c, 0x8000062d, 0x00000000, 0x00000000 }, false);
+    verifyExportedKey(keyTemplate, keyPair, chainCode, new int[] { 0x8000002b, 0x8000003c, 0x8000062d, 0x00000000, 0x00000000 }, false, false);
 
     // Derive without making current
     response = cmdSet.exportKey(new byte[] {(byte) 0x00, 0x00, 0x00, 0x01}, KeycardApplet.DERIVE_P1_SOURCE_PARENT, false,false);
     assertEquals(0x9000, response.getSw());
     keyTemplate = response.getData();
-    verifyExportedKey(keyTemplate, keyPair, chainCode, new int[] { 0x8000002b, 0x8000003c, 0x8000062d, 0x00000000, 0x00000001 }, false);
+    verifyExportedKey(keyTemplate, keyPair, chainCode, new int[] { 0x8000002b, 0x8000003c, 0x8000062d, 0x00000000, 0x00000001 }, false, false);
     response = cmdSet.getStatus(KeycardApplet.GET_STATUS_P1_KEY_PATH);
     assertEquals(0x9000, response.getSw());
     assertArrayEquals(new byte[] {(byte) 0x80, 0x00, 0x00, 0x2B, (byte) 0x80, 0x00, 0x00, 0x3C, (byte) 0x80, 0x00, 0x06, 0x2D, (byte) 0x00, 0x00, 0x00, 0x00, (byte) 0x00, 0x00, 0x00, 0x00}, response.getData());
@@ -1302,7 +1302,16 @@ public class KeycardTest {
     response = cmdSet.exportCurrentKey(false);
     assertEquals(0x9000, response.getSw());
     keyTemplate = response.getData();
-    verifyExportedKey(keyTemplate, keyPair, chainCode, new int[] { 0x8000002b, 0x8000003c, 0x8000062d, 0x00000000, 0x00000000 }, false);
+    verifyExportedKey(keyTemplate, keyPair, chainCode, new int[] { 0x8000002b, 0x8000003c, 0x8000062d, 0x00000000, 0x00000000 }, false, false);
+
+    // Export extended public
+    response = cmdSet.exportExtendedPublicKey(new byte[] {(byte) 0x80, 0x00, 0x00, 0x2B, (byte) 0x80, 0x00, 0x00, 0x3C, (byte) 0x80, 0x00, 0x06, 0x2D, (byte) 0x00, 0x00, 0x00, 0x00, (byte) 0x00, 0x00, 0x00, 0x00}, KeycardApplet.DERIVE_P1_SOURCE_MASTER);
+    assertEquals(0x6985, response.getSw());
+
+    response = cmdSet.exportExtendedPublicKey(new byte[] {(byte) 0x80, 0x00, 0x00, 0x2B, (byte) 0x80, 0x00, 0x00, 0x3C, (byte) 0x80, 0x00, 0x06, 0x2c, (byte) 0x00, 0x00, 0x00, 0x00}, KeycardApplet.DERIVE_P1_SOURCE_MASTER);
+    assertEquals(0x9000, response.getSw());
+    keyTemplate = response.getData();
+    verifyExportedKey(keyTemplate, keyPair, chainCode, new int[] { 0x8000002b, 0x8000003c, 0x8000062c, 0x00000000 }, true, true);
 
     // Reset
     response = cmdSet.deriveKey(new byte[0], KeycardApplet.DERIVE_P1_SOURCE_MASTER);
@@ -1673,19 +1682,29 @@ public class KeycardTest {
     }
   }
 
-  private void verifyExportedKey(byte[] keyTemplate, KeyPair keyPair, byte[] chainCode, int[] path, boolean publicOnly) {
+  private void verifyExportedKey(byte[] keyTemplate, KeyPair keyPair, byte[] chainCode, int[] path, boolean publicOnly, boolean extendedPublic) {
     if (!cmdSet.getApplicationInfo().hasKeyManagementCapability()) {
       return;
     }
 
-    ECKey key = deriveKey(keyPair, chainCode, path).decompress();
+    DeterministicKey dk = deriveKey(keyPair, chainCode, path);
+    ECKey key = dk.decompress();
     assertEquals(KeycardApplet.TLV_KEY_TEMPLATE, keyTemplate[0]);
     int pubKeyLen = 0;
 
     if (publicOnly) {
       assertEquals(KeycardApplet.TLV_PUB_KEY, keyTemplate[2]);
       byte[] pubKey = Arrays.copyOfRange(keyTemplate, 4, 4 + keyTemplate[3]);
-      assertArrayEquals(key.getPubKey(), pubKey);
+      byte[] correctPub = key.getPubKey();
+      
+      if (extendedPublic) {
+        byte[] chain = dk.getChainCode();
+        int len = correctPub.length;
+        correctPub = Arrays.copyOf(correctPub, len + chain.length);
+        System.arraycopy(chain, 0, correctPub, len, chain.length);
+      }
+
+      assertArrayEquals(correctPub, pubKey);
       pubKeyLen = 2 + pubKey.length;
       assertEquals(pubKeyLen, keyTemplate[1]);
       assertEquals(pubKeyLen + 2, keyTemplate.length);

--- a/src/test/java/im/status/keycard/KeycardTest.java
+++ b/src/test/java/im/status/keycard/KeycardTest.java
@@ -1687,7 +1687,6 @@ public class KeycardTest {
       return;
     }
 
-    System.out.println(Hex.toHexString(keyTemplate));
     DeterministicKey dk = deriveKey(keyPair, chainCode, path);
     ECKey key = dk.decompress();
     assertEquals(KeycardApplet.TLV_KEY_TEMPLATE, keyTemplate[0]);

--- a/src/test/java/im/status/keycard/TestKeycardCommandSet.java
+++ b/src/test/java/im/status/keycard/TestKeycardCommandSet.java
@@ -2,6 +2,7 @@ package im.status.keycard;
 
 import im.status.keycard.applet.ApplicationStatus;
 import im.status.keycard.applet.KeycardCommandSet;
+import im.status.keycard.io.APDUCommand;
 import im.status.keycard.io.APDUResponse;
 import im.status.keycard.io.CardChannel;
 import org.web3j.crypto.ECKeyPair;
@@ -12,12 +13,17 @@ import java.security.interfaces.ECPrivateKey;
 
 
 public class TestKeycardCommandSet extends KeycardCommandSet {
+  private CardChannel ac;
+  private TestSecureChannelSession sc;
+
   public TestKeycardCommandSet(CardChannel apduChannel) {
     super(apduChannel);
+    ac = apduChannel;
   }
 
   public void setSecureChannel(TestSecureChannelSession secureChannel) {
     super.setSecureChannel(secureChannel);
+    sc = secureChannel;
   }
 
   /**
@@ -76,6 +82,11 @@ public class TestKeycardCommandSet extends KeycardCommandSet {
 
     return loadKey(data, LOAD_KEY_P1_SEED);
   }
+
+  public APDUResponse exportExtendedPublicKey(byte[] keyPath, byte source) throws IOException {
+    APDUCommand exportKey = sc.protectedCommand(0x80, 0xc2, (source | 0x01), 2, keyPath);
+    return sc.transmit(ac, exportKey);
+  }  
 
   /**
    * Sends a GET STATUS APDU to retrieve the APPLICATION STATUS template and reads the byte indicating key initialization


### PR DESCRIPTION
Allowings exporting extended public keys opens new usage scenarios especially together with Keycard Pro. Removing the derivation caches makes the applet have a smaller memory footprint and reflects the current card usage. It also makes simpler to implement plausable deniability