### PR TITLE
feat: expose occupied pairing slot bitmask in SELECT response

### DIFF
--- a/src/main/java/im/status/keycard/KeycardApplet.java
+++ b/src/main/java/im/status/keycard/KeycardApplet.java
@@ -113,6 +113,7 @@ public class KeycardApplet extends Applet {
   static final byte TLV_UID = (byte) 0x8F;
   static final byte TLV_KEY_UID = (byte) 0x8E;
   static final byte TLV_CAPABILITIES = (byte) 0x8D;
+  static final byte TLV_PAIRING_SLOTS = (byte) 0x8C;
 
   static final byte CAPABILITY_SECURE_CHANNEL = (byte) 0x01;
   static final byte CAPABILITY_KEY_MANAGEMENT = (byte) 0x02;
@@ -480,6 +481,10 @@ public class KeycardApplet extends Applet {
     apduBuffer[off++] = TLV_CAPABILITIES;
     apduBuffer[off++] = 1;
     apduBuffer[off++] = (byte) (APPLICATION_CAPABILITIES | (masterSsk.isInitialized() ? CAPABILITY_LEE : (byte) 0));
+    apduBuffer[off++] = TLV_PAIRING_SLOTS;
+    apduBuffer[off++] = 2;
+    Util.setShort(apduBuffer, off, secureChannel.getOccupiedPairingSlots());
+    off += 2;
 
     apduBuffer[lenoff] = (byte)(off - lenoff - 1);
     apdu.setOutgoingAndSend((short) 0, off);

--- a/src/main/java/im/status/keycard/SecureChannel.java
+++ b/src/main/java/im/status/keycard/SecureChannel.java
@@ -428,6 +428,20 @@ public class SecureChannel {
   }
 
   /**
+   * Returns a bitmask of occupied pairing slots. Bit N is set if slot N is occupied.
+   */
+  public short getOccupiedPairingSlots() {
+    short mask = 0;
+    short slot = 0;
+
+    for (short i = 0; i < (short) pairingKeys.length; i += PAIRING_KEY_LENGTH) {
+      mask |= (short)(pairingKeys[i] << slot++);
+    }
+
+    return mask;
+  }
+
+  /**
    * Resets the Secure Channel, invalidating the current session. If no session is opened, this does nothing.
    */
   public void reset() {

--- a/src/test/java/im/status/keycard/KeycardTest.java
+++ b/src/test/java/im/status/keycard/KeycardTest.java
@@ -479,6 +479,52 @@ public class KeycardTest {
   }
 
   @Test
+  @DisplayName("Pairing slots bitmask in SELECT response")
+  @Capabilities("secureChannel")
+  void pairingSlotsBitmaskTest() throws Exception {
+    Pairing originalPairing = cmdSet.getPairing();
+
+    int initialMask = parsePairingSlotsMask(cmdSet.select().getData());
+    assertTrue((initialMask & (1 << (originalPairing.getPairingIndex() & 0xFF))) != 0);
+
+    // Pair a second slot and verify bitmask grows
+    cmdSet.autoPair(sharedSecret);
+    byte secondIndex = secureChannel.getPairingIndex();
+
+    int twoSlotMask = parsePairingSlotsMask(cmdSet.select().getData());
+    assertTrue((twoSlotMask & (1 << (originalPairing.getPairingIndex() & 0xFF))) != 0);
+    assertTrue((twoSlotMask & (1 << secondIndex)) != 0);
+
+    // Unpair second slot and verify bitmask shrinks
+    cmdSet.autoOpenSecureChannel();
+
+    if (cmdSet.getApplicationInfo().hasCredentialsManagementCapability()) {
+      APDUResponse response = cmdSet.verifyPIN("000000");
+      assertEquals(0x9000, response.getSw());
+    }
+
+    APDUResponse response = cmdSet.unpair(secondIndex);
+    assertEquals(0x9000, response.getSw());
+
+    int afterUnpairMask = parsePairingSlotsMask(cmdSet.select().getData());
+    assertTrue((afterUnpairMask & (1 << (originalPairing.getPairingIndex() & 0xFF))) != 0);
+    assertEquals(0, afterUnpairMask & (1 << secondIndex));
+
+    // Restore original pairing so tearDown can open secure channel
+    cmdSet.setPairing(originalPairing);
+  }
+
+  private int parsePairingSlotsMask(byte[] selectData) {
+    // TLV_PAIRING_SLOTS (0x8C) tag, find it by scanning after the template header
+    for (int i = 0; i < selectData.length - 2; i++) {
+      if ((selectData[i] & 0xFF) == (KeycardApplet.TLV_PAIRING_SLOTS & 0xFF) && (selectData[i + 1] & 0xFF) == 2) {
+        return ((selectData[i + 2] & 0xFF) << 8) | (selectData[i + 3] & 0xFF);
+      }
+    }
+    throw new IllegalArgumentException("TLV_PAIRING_SLOTS not found in SELECT response");
+  }
+
+  @Test
   @DisplayName("GET STATUS command")
   void getStatusTest() throws Exception {
     APDUResponse response;


### PR DESCRIPTION
## Summary

Currently the SELECT response only tells you how many pairing slots are free, but not which specific slots are occupied. This means a client has no way to know which slots are worth deleting. The user could unpair a slot that was already empty and end up with the same number of free slots as before, which is confusing and pointless.

This adds a 2-byte bitmask to the SELECT response (tag 0x8C) where bit N is set if slot N is occupied. Clients can use this to show only occupied slots in any "manage pairings" UI, so the user only sees slots that actually do something when deleted.

The field is appended after the existing capabilities tag, so old clients that stop parsing there are unaffected.

The new bitmask makes the existing free slots count (TLV_INT before TLV_KEY_UID) redundant. The number of free slots can be derived by counting the zero bits. It is kept as-is for backwards compatibility.

## Changes

- SecureChannel: add getOccupiedPairingSlots() returning a short bitmask
- KeycardApplet: include bitmask in SELECT response as TLV_PAIRING_SLOTS (0x8C)
- ApplicationInfo (SDK): parse the new field, expose via getOccupiedPairingSlots()
- Tests: verify bitmask reflects paired/unpaired state