### PR TITLE
fix(SECP256k1): preserve message hash before it's aliased by sign output

### DIFF
--- a/src/main/java/im/status/keycard/SECP256k1.java
+++ b/src/main/java/im/status/keycard/SECP256k1.java
@@ -55,8 +55,6 @@ public class SECP256k1 {
   private static final short SCHNORR_PUB_OFF = (short) 32;
   private static final short SCHNORR_K_OFF = (short) 97;
   private static final short SCHNORR_OUT_SIG_OFF = (short) 34;
-  // Free scratch region (SCHNORR_K_OFF + 32 = 129; Crypto.SCRATCH_SIZE = 176, so 32 bytes fit
-  // here with room to spare) used to preserve the message hash — see schnorrSign() below.
   private static final short SCHNORR_HASH_OFF = (short) 129;
 
   static final byte SIGN_ECDSA = 0x00;
@@ -149,12 +147,6 @@ public class SECP256k1 {
   }
 
   short schnorrSign(Crypto crypto, ECPrivateKey key, byte[] hash, short hashOff, byte[] out, short outOff) {
-    // `hash` and `out` may alias — KeycardApplet.sign() lays out the APDU buffer so the
-    // signature output offset lands exactly on the hash's own offset (safe for the hardware
-    // ECDSA path, which fully consumes its input before writing output, but not for this
-    // software implementation, which writes the public key into `out` below before `hash` has
-    // been read for the nonce/challenge digests). Copy the hash out to scratch space first so
-    // the rest of this method can't read a value that this method itself already overwrote.
     Util.arrayCopyNonAtomic(hash, hashOff, crypto.scratch, SCHNORR_HASH_OFF, (short) 32);
     hash = crypto.scratch;
     hashOff = SCHNORR_HASH_OFF;

--- a/src/main/java/im/status/keycard/SECP256k1.java
+++ b/src/main/java/im/status/keycard/SECP256k1.java
@@ -55,6 +55,9 @@ public class SECP256k1 {
   private static final short SCHNORR_PUB_OFF = (short) 32;
   private static final short SCHNORR_K_OFF = (short) 97;
   private static final short SCHNORR_OUT_SIG_OFF = (short) 34;
+  // Free scratch region (SCHNORR_K_OFF + 32 = 129; Crypto.SCRATCH_SIZE = 176, so 32 bytes fit
+  // here with room to spare) used to preserve the message hash — see schnorrSign() below.
+  private static final short SCHNORR_HASH_OFF = (short) 129;
 
   static final byte SIGN_ECDSA = 0x00;
   static final byte SIGN_ED25519 = 0x01;
@@ -146,6 +149,16 @@ public class SECP256k1 {
   }
 
   short schnorrSign(Crypto crypto, ECPrivateKey key, byte[] hash, short hashOff, byte[] out, short outOff) {
+    // `hash` and `out` may alias — KeycardApplet.sign() lays out the APDU buffer so the
+    // signature output offset lands exactly on the hash's own offset (safe for the hardware
+    // ECDSA path, which fully consumes its input before writing output, but not for this
+    // software implementation, which writes the public key into `out` below before `hash` has
+    // been read for the nonce/challenge digests). Copy the hash out to scratch space first so
+    // the rest of this method can't read a value that this method itself already overwrote.
+    Util.arrayCopyNonAtomic(hash, hashOff, crypto.scratch, SCHNORR_HASH_OFF, (short) 32);
+    hash = crypto.scratch;
+    hashOff = SCHNORR_HASH_OFF;
+
     key.getS(crypto.scratch, SCHNORR_SK_OFF);
     schnorrPrivPub(crypto, crypto.scratch, SCHNORR_SK_OFF);
     Util.arrayCopyNonAtomic(crypto.scratch, (short) (SCHNORR_PUB_OFF + 1), out, outOff, (short) 32);


### PR DESCRIPTION
KeycardApplet.sign() lays out the APDU response buffer so the signature output offset (sigOff) lands exactly on the offset the message hash was copied to (SIGN_HASH_OFF) — sigOff == SIGN_HASH_OFF for every algorithm. This is harmless for ecdsaSign(), which calls into the platform's hardware Signature engine and fully consumes the hash before writing output, but schnorrSign() is a software implementation that writes the public key's x-coordinate into `out` before the hash is read again for the nonce and challenge digests.

When sigOff and hashOff alias (as they always do via KeycardApplet.sign()), this overwrites the message hash with the public key's x-coordinate before it's used, so the card ends up producing a valid BIP340 signature over the wrong message (its own derived pubkey) instead of the caller's message. Confirmed against real hardware: every signature failed verification against the real message but verified cleanly against the pubkey-as-message instead.

Fix: copy the hash to scratch space at the very start of schnorrSign(), before anything can write to a possibly-aliased `out`, and operate on that copy for the rest of the method.